### PR TITLE
Changed the handler types to the same functions, but with an error re…

### DIFF
--- a/apollo_test.go
+++ b/apollo_test.go
@@ -21,9 +21,13 @@ func TestHandlerFunc(t *testing.T) {
 		handler := HandlerFunc(handlerOne)
 		assert.Implements((*Handler)(nil), handler)
 
-		handler.ServeHTTP(ctx, w, r)
+		err := handler.ServeHTTP(ctx, w, r)
 		assert.Equal(w.Code, 200)
 		assert.Equal(w.Body.String(), "h1\n")
+		if err != nil {
+			assert.Equal(err.Error(), "h1\n")
+		}
+
 	})
 }
 
@@ -54,6 +58,7 @@ func TestStripsContextServe(t *testing.T) {
 		adapter.ServeHTTP(ctx, w, r)
 		assert.Equal(w.Code, 200)
 		assert.Equal(w.Body.String(), "h0\n")
+
 	})
 }
 
@@ -84,4 +89,86 @@ func TestWrapChains(t *testing.T) {
 
 	assert.Equal(200, res.StatusCode)
 	assert.Equal("m1\nm0\nm2\n10\n", string(body))
+}
+
+func TestWrapChainsWithNilErrorContext(t *testing.T) {
+	assert := assert.New(t)
+	ctx := NewTestContext(context.Background(), 10)
+	value, _ := FromContext(ctx)
+	assert.Equal(value, 10)
+
+	chain := New(middleHandleError, Wrap(middleZero), middleTwo).With(ctx).ThenFunc(handlerContext)
+
+	ts := httptest.NewServer(chain)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(err)
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	assert.Equal(200, res.StatusCode)
+	assert.Equal("m0\nm2\n10\n", string(body))
+}
+
+func TestWrapChainsWithErrorOne(t *testing.T) {
+	assert := assert.New(t)
+	ctx := NewTestContext(context.Background(), 10)
+	value, _ := FromContext(ctx)
+	assert.Equal(value, 10)
+
+	chain := New(middleHandleError, Wrap(middleZero), middleTwo).With(ctx).ThenFunc(handlerError)
+
+	ts := httptest.NewServer(chain)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(err)
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	assert.Equal(200, res.StatusCode)
+	assert.Equal("m0\nm2\nerror:err1\n", string(body))
+}
+
+func TestWrapChainsWithErrorWithEmptyContext(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	chain := New(middleHandleError, Wrap(middleZero), middleTwo).With(ctx).ThenFunc(handlerContext)
+
+	ts := httptest.NewServer(chain)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(err)
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	assert.Equal(200, res.StatusCode)
+	assert.Equal("m0\nm2\nerror:value not in context\n", string(body))
+}
+
+func TestWrapChainsWithMultipleErrors(t *testing.T) {
+	assert := assert.New(t)
+	ctx := NewTestContext(context.Background(), 10)
+	value, _ := FromContext(ctx)
+	assert.Equal(value, 10)
+
+	chain := New(middleHandleError, Wrap(middleZero), middleTwo, middleAddError).With(ctx).ThenFunc(handlerError)
+
+	ts := httptest.NewServer(chain)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(err)
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	assert.Equal(200, res.StatusCode)
+	assert.Equal("m0\nm2\nerror:err1\nerror:found an error\n", string(body))
 }


### PR DESCRIPTION
…turn value. Tested it and errors can be carried over from regular http.Handlers if they are wrapped, just the same way as the context can be carried over. stripsContext will negate the error passing properties and return nil.
